### PR TITLE
fix buffer boundary issues and cursor handling in IK tokenizer

### DIFF
--- a/core/src/main/java/org/wltea/analyzer/core/AnalyzeContext.java
+++ b/core/src/main/java/org/wltea/analyzer/core/AnalyzeContext.java
@@ -121,15 +121,20 @@ class AnalyzeContext {
     		readCount = reader.read(segmentBuff);
 			this.lastUselessCharNum = 0;
     	}else{
-    		int offset = this.available - this.cursor;
+			// moveCursor()只能将cursor移动到available-1，需要+1
+    		int offset = this.available - (this.cursor + 1);
     		if(offset > 0){
     			//最近一次读取的>最近一次处理的，将未处理的字串拷贝到segmentBuff头部
-    			System.arraycopy(this.segmentBuff , this.cursor , this.segmentBuff , 0 , offset);
+				//当前cursor是已经处理过的字符，需要+1
+    			System.arraycopy(this.segmentBuff , this.cursor + 1, this.segmentBuff , 0 , offset);
     			readCount = offset;
     		}
     		//继续读取reader ，以onceReadIn - onceAnalyzed为起始位置，继续填充segmentBuff剩余的部分
-    		readCount += reader.read(this.segmentBuff , offset , BUFF_SIZE - offset);
-    	}            	
+    		int numRead = reader.read(this.segmentBuff, offset, BUFF_SIZE - offset);
+			if (numRead != -1) {
+				readCount += numRead;
+			}
+    	}
     	//记录最后一次从Reader中读入的可用字符长度
     	this.available = readCount;
     	//重置当前指针


### PR DESCRIPTION
medcl你好，我发现了fillBuffer()在特定情况下会导致最后一个字符被重复消费的问题。

修改fillBuffer()中offset的计算，可以正确处理缓冲区已经处理完的情况，原代码会在特定情况下重复消费最后一个字符。

Adjusted the calculation of offset in fillBuffer() to correctly handle cases when the cursor reaches the end of the buffer, preventing duplicate processing of the last character.

Case: 
useSmart: true
str = "中华人民共和国"; 

1. BUFF_SIZE = 4096
results: [中华人民共和国]

2. BUFF_SIZE = 6
results: [中华人民, 共和, 和, 国]
The character '和' was processed twice.
'和'被重复处理了两次

Updated code:
BUFF_SIZE = 6
results: [中华人民, 共和,  国]

我不太清楚触发offset>0的情况，如果出现该情况，当前的cursor表示的字符是否被处理？