### PR TITLE
修复安装9.0.0后es无法启动的问题

### DIFF
--- a/elasticsearch/pom.xml
+++ b/elasticsearch/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>analysis-ik</artifactId>
         <groupId>com.infinilabs</groupId>

--- a/elasticsearch/src/main/java/com/infinilabs/ik/elasticsearch/IkAnalyzerProvider.java
+++ b/elasticsearch/src/main/java/com/infinilabs/ik/elasticsearch/IkAnalyzerProvider.java
@@ -10,23 +10,22 @@ import org.wltea.analyzer.lucene.IKAnalyzer;
 public class IkAnalyzerProvider extends AbstractIndexAnalyzerProvider<IKAnalyzer> {
     private final IKAnalyzer analyzer;
 
-    public IkAnalyzerProvider(IndexSettings indexSettings, Environment env, String name, Settings settings,boolean useSmart) {
-        super(name, settings);
-
-        Configuration configuration = new ConfigurationSub(env,settings).setUseSmart(useSmart);
-
-        analyzer=new IKAnalyzer(configuration);
+    public IkAnalyzerProvider(IndexSettings indexSettings, Environment env, String name, Settings settings, boolean useSmart) {
+        super(name);
+        Configuration configuration = new ConfigurationSub(env, settings).setUseSmart(useSmart);
+        analyzer = new IKAnalyzer(configuration);
     }
 
     public static IkAnalyzerProvider getIkSmartAnalyzerProvider(IndexSettings indexSettings, Environment env, String name, Settings settings) {
-        return new IkAnalyzerProvider(indexSettings,env,name,settings,true);
+        return new IkAnalyzerProvider(indexSettings, env, name, settings, true);
     }
 
     public static IkAnalyzerProvider getIkAnalyzerProvider(IndexSettings indexSettings, Environment env, String name, Settings settings) {
-        return new IkAnalyzerProvider(indexSettings,env,name,settings,false);
+        return new IkAnalyzerProvider(indexSettings, env, name, settings, false);
     }
 
-    @Override public IKAnalyzer get() {
+    @Override
+    public IKAnalyzer get() {
         return this.analyzer;
     }
 }

--- a/elasticsearch/src/main/java/com/infinilabs/ik/elasticsearch/IkTokenizerFactory.java
+++ b/elasticsearch/src/main/java/com/infinilabs/ik/elasticsearch/IkTokenizerFactory.java
@@ -9,27 +9,28 @@ import org.wltea.analyzer.cfg.Configuration;
 import org.wltea.analyzer.lucene.IKTokenizer;
 
 public class IkTokenizerFactory extends AbstractTokenizerFactory {
-  private Configuration configuration;
+    private Configuration configuration;
 
-  public IkTokenizerFactory(IndexSettings indexSettings, Environment env, String name, Settings settings) {
-      super(indexSettings, settings,name);
-      configuration = new ConfigurationSub(env,settings);
-  }
+    public IkTokenizerFactory(IndexSettings indexSettings, Environment env, String name, Settings settings) {
+        super(name);
+        configuration = new ConfigurationSub(env, settings);
+    }
 
-  public static IkTokenizerFactory getIkTokenizerFactory(IndexSettings indexSettings, Environment env, String name, Settings settings) {
-      return new IkTokenizerFactory(indexSettings,env, name, settings).setSmart(false);
-  }
+    public static IkTokenizerFactory getIkTokenizerFactory(IndexSettings indexSettings, Environment env, String name, Settings settings) {
+        return new IkTokenizerFactory(indexSettings, env, name, settings).setSmart(false);
+    }
 
-  public static IkTokenizerFactory getIkSmartTokenizerFactory(IndexSettings indexSettings, Environment env, String name, Settings settings) {
-      return new IkTokenizerFactory(indexSettings,env, name, settings).setSmart(true);
-  }
+    public static IkTokenizerFactory getIkSmartTokenizerFactory(IndexSettings indexSettings, Environment env, String name, Settings settings) {
+        return new IkTokenizerFactory(indexSettings, env, name, settings).setSmart(true);
+    }
 
-  public IkTokenizerFactory setSmart(boolean smart){
+    public IkTokenizerFactory setSmart(boolean smart) {
         this.configuration.setUseSmart(smart);
         return this;
-  }
+    }
 
-  @Override
-  public Tokenizer create() {
-      return new IKTokenizer(configuration);  }
+    @Override
+    public Tokenizer create() {
+        return new IKTokenizer(configuration);
+    }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <name>analysis-ik</name>
-     <modules>
+    <modules>
         <module>core</module>
         <module>elasticsearch</module>
         <module>opensearch</module>
-      </modules>
-    
+    </modules>
+
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.infinilabs</groupId>
     <artifactId>analysis-ik</artifactId>
@@ -18,10 +18,10 @@
 
     <properties>
         <lucene.version>9.3.0</lucene.version>
-        <elasticsearch.version>8.18.0</elasticsearch.version>
+        <elasticsearch.version>9.0.0</elasticsearch.version>
         <opensearch.version>2.0.1</opensearch.version>
         <maven.compiler.target>1.8</maven.compiler.target>
-   
+
         <tests.rest.load_packaged>false</tests.rest.load_packaged>
         <skip.unit.tests>true</skip.unit.tests>
         <gpg.keyname>4E899B30</gpg.keyname>
@@ -73,8 +73,12 @@
         <repository>
             <id>oss.sonatype.org</id>
             <name>OSS Sonatype</name>
-            <releases><enabled>true</enabled></releases>
-            <snapshots><enabled>true</enabled></snapshots>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
             <url>https://oss.sonatype.org/content/repositories/releases/</url>
         </repository>
     </repositories>
@@ -128,83 +132,83 @@
                 <additionalparam>-Xdoclint:none</additionalparam>
             </properties>
         </profile>
-            <profile>
-                <id>release</id>
-                <build>
-                    <plugins>
-                        <plugin>
-                            <groupId>org.sonatype.plugins</groupId>
-                            <artifactId>nexus-staging-maven-plugin</artifactId>
-                            <version>1.6.3</version>
-                            <extensions>true</extensions>
-                            <configuration>
-                                <serverId>oss</serverId>
-                                <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                                <autoReleaseAfterClose>true</autoReleaseAfterClose>
-                            </configuration>
-                        </plugin>
-                        <plugin>
-                            <groupId>org.apache.maven.plugins</groupId>
-                            <artifactId>maven-release-plugin</artifactId>
-                            <version>2.1</version>
-                            <configuration>
-                                <autoVersionSubmodules>true</autoVersionSubmodules>
-                                <useReleaseProfile>false</useReleaseProfile>
-                                <releaseProfiles>release</releaseProfiles>
-                                <goals>deploy</goals>
-                            </configuration>
-                        </plugin>
-                        <plugin>
-                            <groupId>org.apache.maven.plugins</groupId>
-                            <artifactId>maven-compiler-plugin</artifactId>
-                            <version>3.5.1</version>
-                            <configuration>
-                                <source>${maven.compiler.target}</source>
-                                <target>${maven.compiler.target}</target>
-                            </configuration>
-                        </plugin>
-                        <plugin>
-                            <groupId>org.apache.maven.plugins</groupId>
-                            <artifactId>maven-gpg-plugin</artifactId>
-                            <version>1.5</version>
-                            <executions>
-                                <execution>
-                                    <id>sign-artifacts</id>
-                                    <phase>verify</phase>
-                                    <goals>
-                                        <goal>sign</goal>
-                                    </goals>
-                                </execution>
-                            </executions>
-                        </plugin>
-                        <plugin>
-                            <groupId>org.apache.maven.plugins</groupId>
-                            <artifactId>maven-source-plugin</artifactId>
-                            <version>2.2.1</version>
-                            <executions>
-                                <execution>
-                                    <id>attach-sources</id>
-                                    <goals>
-                                        <goal>jar-no-fork</goal>
-                                    </goals>
-                                </execution>
-                            </executions>
-                        </plugin>
-                        <plugin>
-                            <groupId>org.apache.maven.plugins</groupId>
-                            <artifactId>maven-javadoc-plugin</artifactId>
-                            <version>2.9</version>
-                            <executions>
-                                <execution>
-                                    <id>attach-javadocs</id>
-                                    <goals>
-                                        <goal>jar</goal>
-                                    </goals>
-                                </execution>
-                            </executions>
-                        </plugin>
-                    </plugins>
-                </build>
-            </profile>
+        <profile>
+            <id>release</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.sonatype.plugins</groupId>
+                        <artifactId>nexus-staging-maven-plugin</artifactId>
+                        <version>1.6.3</version>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <serverId>oss</serverId>
+                            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+                            <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-release-plugin</artifactId>
+                        <version>2.1</version>
+                        <configuration>
+                            <autoVersionSubmodules>true</autoVersionSubmodules>
+                            <useReleaseProfile>false</useReleaseProfile>
+                            <releaseProfiles>release</releaseProfiles>
+                            <goals>deploy</goals>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <version>3.5.1</version>
+                        <configuration>
+                            <source>${maven.compiler.target}</source>
+                            <target>${maven.compiler.target}</target>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>1.5</version>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-source-plugin</artifactId>
+                        <version>2.2.1</version>
+                        <executions>
+                            <execution>
+                                <id>attach-sources</id>
+                                <goals>
+                                    <goal>jar-no-fork</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <version>2.9</version>
+                        <executions>
+                            <execution>
+                                <id>attach-javadocs</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 </project>


### PR DESCRIPTION
升级到9.0.0并安装analysis-ik后启动报错如下
![1](https://github.com/user-attachments/assets/d42a278b-01c6-40c0-a9ab-d0b5c53737f1)
原因是es发生了以下更改
https://github.com/elastic/elasticsearch/pull/118167/files
请重新构建一份9.0.0

modified:   elasticsearch/pom.xml
modified:   elasticsearch/src/main/java/com/infinilabs/ik/elasticsearch/IkAnalyzerProvider.java
modified:   elasticsearch/src/main/java/com/infinilabs/ik/elasticsearch/IkTokenizerFactory.java
modified:   pom.xml