### PR TITLE
fix: update jdk version to fix ci maven error

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -21,10 +21,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up JDK 17
+    - name: Set up JDK 24
       uses: actions/setup-java@v4
       with:
-        java-version: '17'
+        java-version: '24'
         distribution: 'temurin'
         cache: maven
     - name: Run the Maven verify phase


### PR DESCRIPTION
This pull request updates the Java Development Kit (JDK) version used in the Maven workflow configuration. 

Workflow configuration changes:

* [`.github/workflows/maven.yml`](diffhunk://#diff-5dbf1a803ecc13ff945a08ed3eb09149a83615e83f15320550af8e3a91976446L24-R27): Updated the JDK version from 17 to 24 in the `Set up JDK` step, ensuring compatibility with newer Java features and updates.